### PR TITLE
feat(fonts): Remove web font support

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,13 +223,6 @@ const decorateClientConfig = (config, options) => {
         })
     : loaders => [require.resolve('style-loader'), ...loaders];
 
-  const extractWoff = new ExtractTextPlugin({
-    filename: 'roboto.woff.css'
-  });
-  const extractWoff2 = new ExtractTextPlugin({
-    filename: 'roboto.woff2.css'
-  });
-
   return decorateConfig(config, allIncludes, {
     rules: [
       {
@@ -253,38 +246,8 @@ const decorateClientConfig = (config, options) => {
           },
           require.resolve('less-loader')
         ])
-      },
-      {
-        test: /Roboto.woff.css$/,
-        include: allIncludes,
-        use: extractWoff.extract({
-          use: {
-            loader: require.resolve('css-loader'),
-            options: {
-              minimize: true
-            }
-          }
-        })
-      },
-      {
-        test: /Roboto.woff2.css$/,
-        include: allIncludes,
-        use: extractWoff2.extract({
-          use: {
-            loader: require.resolve('css-loader'),
-            options: {
-              minimize: true
-            }
-          }
-        })
-      },
-      {
-        test: /\.woff2?$/,
-        include: allIncludes,
-        use: require.resolve('base64-font-loader')
       }
-    ],
-    plugins: [extractWoff, extractWoff2]
+    ]
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.23.0",
-    "base64-font-loader": "0.0.4",
     "chalk": "^1.1.3",
     "css-loader": "^0.26.1",
     "less-loader": "^2.2.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "webpack-node-externals": "^1.5.4"
   },
   "peerDependencies": {
-    "seek-style-guide": "*"
+    "seek-style-guide": ">=26.0.0"
   },
   "devDependencies": {
     "classnames": "^2.2.5",

--- a/test/app/client-render.js
+++ b/test/app/client-render.js
@@ -1,5 +1,3 @@
-require('seek-style-guide/fonts/bundle');
-
 import React from 'react';
 import { render } from 'react-dom';
 import App from './App';


### PR DESCRIPTION
BREAKING CHANGE: Web font imports will no longer work.

Might be worth holding off on this until web fonts are removed from the style guide and we can add the appropriate minimum version number as a peer dependency.