### PR TITLE
fix(link): Throw error when module is linked locally

### DIFF
--- a/incorrectStyleGuidePath.js
+++ b/incorrectStyleGuidePath.js
@@ -1,6 +1,8 @@
 const path = require('path');
 
+const notTesting = process.env.NODE_ENV !== 'test';
+
 const explicitlyResolvedIncorrectPath = path.resolve(__dirname, 'node_modules/seek-style-guide');
 const resolvedPath = require.resolve('seek-style-guide');
 
-module.exports = resolvedPath.indexOf(explicitlyResolvedIncorrectPath) > -1;
+module.exports = notTesting && resolvedPath.indexOf(explicitlyResolvedIncorrectPath) > -1;

--- a/incorrectStyleGuidePath.js
+++ b/incorrectStyleGuidePath.js
@@ -1,0 +1,6 @@
+const path = require('path');
+
+const explicitlyResolvedIncorrectPath = path.resolve(__dirname, 'node_modules/seek-style-guide');
+const resolvedPath = require.resolve('seek-style-guide');
+
+module.exports = resolvedPath.indexOf(explicitlyResolvedIncorrectPath) > -1;

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ const validateConfig = config => {
     error(
       `
         This module has resolved the style-guide path as ${require.resolve('seek-style-guide')}.
-        That appears incorrect, did you link this module locally? Please unlink it as
+        That appears incorrect, did you link this module locally? Please unlink it,
         it does not resolve correctly when linked locally.
       `
     );

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const nodeExternals = require('webpack-node-externals');
 const chalk = require('chalk');
+const incorrectStyleGuidePath = require('./incorrectStyleGuidePath');
 
 const autoprefixerConfig = require('./autoprefixer.config');
 
@@ -49,6 +50,16 @@ const error = message => {
 };
 
 const validateConfig = config => {
+  if (incorrectStyleGuidePath) {
+    error(
+      `
+        This module has resolved the style path as ${require.resolve('seek-style-guide')}.
+        That appears incorrect, did you link this module locally? Please unlink it as
+        it does not resolve correctly when linked locally.
+      `
+    );
+  }
+
   config.module.rules.forEach(rules => {
     if (!rules.include) {
       error(

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ const validateConfig = config => {
   if (incorrectStyleGuidePath) {
     error(
       `
-        This module has resolved the style path as ${require.resolve('seek-style-guide')}.
+        This module has resolved the style-guide path as ${require.resolve('seek-style-guide')}.
         That appears incorrect, did you link this module locally? Please unlink it as
         it does not resolve correctly when linked locally.
       `

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Webpack config decorator to seek-style-guide applications",
   "main": "index.js",
   "scripts": {
-    "test": "webpack --config test/webpack.config.js",
+    "test": "NODE_ENV=test webpack --config test/webpack.config.js",
     "format": "prettier --single-quote --write '*.js' 'test/**/*.js'",
     "commit": "git-cz",
     "commitmsg": "validate-commit-msg",


### PR DESCRIPTION
This PR creates an error when you link the seek-style-guide-webpack module locally.

Currently, if you do that with this module, you can run into some odd behaviour because of the way that locally linked modules resolve their dependencies.
