### PR TITLE
fix(React): Add displayName to React components

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,8 @@ const getCommonLoaders = (includes) => [
           ],
           plugins: [
             require.resolve('babel-plugin-transform-class-properties'),
-            require.resolve('babel-plugin-transform-object-rest-spread')
+            require.resolve('babel-plugin-transform-object-rest-spread'),
+            require.resolve('babel-plugin-add-react-displayname')
           ]
         }
       }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "autoprefixer": "^6.7.5",
     "babel-core": "^6.23.1",
     "babel-loader": "^6.3.2",
+    "babel-plugin-add-react-displayname": "^0.0.4",
     "babel-plugin-transform-class-properties": "^6.23.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.22.0",


### PR DESCRIPTION
This issue was originally surfaced in the style guide since the documentation uses the `displayName` properties to generate code samples, but this would also impact the ability to inspect React components in production.