### PR TITLE
chore(package): Use caret version range for style guide

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-dom": "^16.0.0",
     "react-helmet": "^5.2.0",
     "react-isolated-scroll": "^0.1.1",
-    "seek-style-guide": "31.0.2",
+    "seek-style-guide": "^31.1.0",
     "semantic-release": "^8.0.3",
     "static-site-generator-webpack-plugin": "^3.4.1",
     "validate-commit-msg": "^2.14.0",


### PR DESCRIPTION
This should reduce the Greenkeeper PR noise by only upgrading the style guide dependency when a major version is released.