### PR TITLE
chore(package): Widen style guide dev dependency range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: node_js
-cache:
-  directories:
-    - node_modules
 notifications:
   email: false
 node_js:

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-dom": "^16.0.0",
     "react-helmet": "^5.2.0",
     "react-isolated-scroll": "^0.1.1",
-    "seek-style-guide": "^31.1.0",
+    "seek-style-guide": ">=26.0.0",
     "semantic-release": "^8.0.3",
     "static-site-generator-webpack-plugin": "^3.4.1",
     "validate-commit-msg": "^2.14.0",


### PR DESCRIPTION
The version range now mirrors the one used for the peer dependency.

This also removes the Travis CI node modules cache to ensure it’s fresh.