### PR TITLE
fix(icons): Revert SVGO & svgo-loader upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "postcss-prefix-selector": "^1.6.0",
     "raw-loader": "^0.5.1",
     "style-loader": "^0.19.0",
-    "svgo": "^1.0.0",
-    "svgo-loader": "^2.0.0",
+    "svgo-loader": "^1.2.1",
     "uglify-loader": "^2.0.0",
     "webpack-node-externals": "^1.6.0"
   },


### PR DESCRIPTION
This PR is to revert commit 763ca139a2be11cf5cca25622914cf334956d20c (release 2.1.2) which was `add missing SVGO dependency, update svgo-loader to v2.0.0 (#28)` as it breaks some SVGs.