### PR TITLE
fix(package): Add missing SVGO dependency, pinned to older version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "postcss-prefix-selector": "^1.6.0",
     "raw-loader": "^0.5.1",
     "style-loader": "^0.19.0",
+    "svgo": "^0.7.2",
     "svgo-loader": "^1.2.1",
     "uglify-loader": "^2.0.0",
     "webpack-node-externals": "^1.6.0"


### PR DESCRIPTION
The seek-style-guide build is currently failing because it's trying to use SVGO v1, which fails with v1 of svgo-loader. This ensures that we're using the correct version of SVGO in the style guide, regardless of which version consumers are using.