### PR TITLE
fix(validation): Error on legacy module loaders config

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,15 @@ const validateConfig = config => {
     );
   }
 
+  if (config.module.loaders !== undefined) {
+    error(
+      `
+        You've configured your loaders with the legacy "module.loaders" field.
+        Please use the newer "module.rules" format instead.
+      `
+    );
+  }
+
   config.module.rules.forEach(rules => {
     if (!rules.include) {
       error(


### PR DESCRIPTION
We just ran into this issue where webpack lets you get away with the old "module.loaders" format in your config, but this is incompatible with the decorators which assume you're using the modern "module.rules" format.

Rather than try to support the old format, I figured it makes more sense to just add this as another validation rule and force consumers to upgrade their config—especially since it'll take about 3 seconds to fix.