### PR TITLE
feat(decorateClientConfig): Upgrade to version 4

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "tabWidth": 2
 }

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ $ npm install --save-dev seek-style-guide-webpack
 First, decorate your server Webpack config:
 
 ```js
-const decorateServerConfig = require('seek-style-guide-webpack')
-  .decorateServerConfig;
+const { decorateServerConfig } = require('seek-style-guide-webpack');
 
 module.exports = decorateServerConfig({
   // Webpack config...
@@ -26,27 +25,41 @@ module.exports = decorateServerConfig({
 Then, decorate your client Webpack config:
 
 ```js
-const decorateClientConfig = require('seek-style-guide-webpack')
-  .decorateClientConfig;
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const { decorateClientConfig } = require('seek-style-guide-webpack');
 
-const extractCss = new ExtractTextPlugin({
-  filename: 'style.css'
+module.exports = decorateClientConfig({
+  // Webpack config...
 });
+```
+
+## Options
+
+### CSS Output Loader `{ cssOutputLoader: <webpack loader> | 'style-loader' }`
+
+By default the client decorator will use [`style-loader`](https://github.com/webpack-contrib/style-loader) to handle the styles emitted from the [`seek-style-guide`](https://github.com/seek-oss/seek-style-guide). Alternatively, you can
+pass in your own loader configuration, eg.
+
+```js
+const { decorateClientConfig } = require('seek-style-guide-webpack');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const config = {
   // Webpack config...
+  plugins: [
+    new MiniCssExtractPlugin(
+      filename: 'style.css'
+    })
+  ]
 };
 
 module.exports = decorateClientConfig(config, {
-  // Ensure you pass your ExtractTextPlugin instance to the decorator, if required:
-  extractTextPlugin: extractCss
+  cssOutputLoader: MiniCssExtractPlugin.loader
 });
 ```
 
 Please note that, if your Webpack loaders aren't scoped to your local project files via the ["include" option](https://webpack.github.io/docs/configuration.html#module-loaders), the decorator will throw an error.
 
-### Extra includes
+### Extra includes (optional) `{ extraIncludePaths: Array<paths> }`
 
 If you have other external node_modules that need to be compiled in the same way as the seek-style-guide then you can pass an extra parameter to the decorators.
 
@@ -57,7 +70,7 @@ module.exports = decorateClientConfig(config, {
 });
 ```
 
-### CSS Selector Prefix
+### CSS Selector Prefix (optional) `{ cssSelectorPrefix: string }`
 
 This selector prefix is automatically prepended to all selectors to ensure styles don't leak out into the global scope.
 For example, this is used for generating the standalone header & footer in the style guide.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "autoprefixer": "^7.1.5",
     "babel-core": "^6.26.0",
-    "babel-loader": "^7.1.2",
+    "babel-loader": "^7.1.5",
     "babel-plugin-add-react-displayname": "^0.0.4",
     "babel-plugin-flow-react-proptypes": "^17.1.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
@@ -56,14 +56,13 @@
     "chalk": "^2.1.0",
     "css-loader": "^0.28.7",
     "less": "^2.7.2",
-    "less-loader": "^4.0.5",
-    "postcss-loader": "^2.0.7",
+    "less-loader": "^4.1.0",
+    "postcss-loader": "^3.0.0",
     "postcss-prefix-selector": "^1.6.0",
     "raw-loader": "^0.5.1",
-    "style-loader": "^0.19.0",
-    "svgo": "^0.7.2",
-    "svgo-loader": "^1.2.1",
-    "uglify-loader": "^2.0.0",
+    "style-loader": "^0.23.1",
+    "svgo": "^1.1.1",
+    "svgo-loader": "^2.2.0",
     "webpack-node-externals": "^1.6.0"
   },
   "peerDependencies": {
@@ -71,15 +70,16 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^7.2.1",
+    "babel-plugin-seek-style-guide": "^1.0.0",
     "classnames": "^2.2.6",
     "commitizen": "^3.0.4",
     "commitlint-config-seek": "^1.0.0",
     "cz-conventional-changelog": "^2.1.0",
-    "extract-text-webpack-plugin": "^3.0.1",
     "husky": "^1.1.4",
     "lint-staged": "^8.0.4",
     "lodash.omit": "^4.5.0",
     "lodash.range": "^3.2.0",
+    "mini-css-extract-plugin": "^0.4.4",
     "pad-left": "^2.1.0",
     "prettier": "^1.15.2",
     "react": "^16.0.0",
@@ -88,6 +88,7 @@
     "seek-style-guide": "^38.5.0",
     "semantic-release": "^15.11.0",
     "static-site-generator-webpack-plugin": "^3.4.1",
-    "webpack": "^3.6.0"
+    "webpack": "^4.25.1",
+    "webpack-cli": "^3.1.2"
   }
 }


### PR DESCRIPTION
Upgrades the decorators to support webpack v4. We have made it this far because most apps are running [sku](https://github.com/seek-oss/sku) which handles this for you.

The primary change for consumers is around the handling of styles emitted from the style guide compilation. The client decorator now has a `cssOutputLoader` option allowing you to configure the final loader in the css pipeline.

BREAKING CHANGE: Removed the client decorator option `extractTextPlugin` in favour of
`cssOutputLoader`. Also upgrading from webpack 3 to 4 so any plugins/loaders would need to be
supported by 4.

#### Migration Guide
Consumers will need to migrate their applications to support webpack v4, which will be project specific based on the webpack config.

Beyond the webpack upgrade, only consumers using the `extractTextPlugin` option in the client decorator need to migrate to the new `cssOutputLoader` option. The `extract-text-webpack-plugin` is not supported in webpack 4, but `mini-css-extract-plugin` is essentially a drop in replacement.

```diff
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');

-const extractCss = new ExtractTextPlugin({
+const extractCss = new MiniCssExtractPlugin({
  filename: 'style.css'
});

const webpackConfig = {
  ...
  plugins: [
    extractCss
  ]
};

module.exports = decorateClientConfig(webpackConfig, {
-  extractTextPlugin: extractCss
+  cssOutputLoader: MiniCssExtractPlugin.loader
});


