### PR TITLE
fix: Disable removing viewBox attribute from svgs

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,6 +129,7 @@ const getCommonLoaders = includes => [
         loader: require.resolve('svgo-loader'),
         options: {
           plugins: [
+            { removeViewBox: false },
             { addAttributesToSVGElement: { attribute: 'focusable="false"' } }
           ]
         }


### PR DESCRIPTION
Upgrading `svgo` when moving to webpack 4 inherited a new default config that would strip the `viewbox` attribute when it matched the `height` and `width` attributes on the `svg`. This is breaking the rendering of the icons in the style guide, so we are disabling this "optimisation".